### PR TITLE
fix: bounding box preference change leading to error

### DIFF
--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -339,14 +339,20 @@ export const detailsQueryAtom = atomWithQuery<
 export const boundingBoxQueryAtom = atomWithQuery<
   ReturnType<typeof fetchBoundingBox>,
   unknown
->((get) => ({
-  queryKey: ["bounding_box"],
-  queryFn: async () => {
-    const tourPreference = get(tourPreferenceAtom);
+>((get) => {
+  const tourPreference = get(tourPreferenceAtom);
 
-    return fetchBoundingBox(tourPreference);
-  },
-}));
+  const keyPrefix = `${tourPreference}_`;
+
+  let preferredQuery = {
+    queryKey: [`${keyPrefix}bounding_box`],
+    queryFn: async () => {
+      return fetchBoundingBox(tourPreference);
+    },
+  };
+
+  return preferredQuery;
+});
 
 export const paddedBoundingBoxAtom = atom<LatLngBounds>((get) => {
   return get(boundingBoxQueryAtom).pad(0.5);

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -342,10 +342,8 @@ export const boundingBoxQueryAtom = atomWithQuery<
 >((get) => {
   const tourPreference = get(tourPreferenceAtom);
 
-  const keyPrefix = `${tourPreference}_`;
-
   let preferredQuery = {
-    queryKey: [`${keyPrefix}bounding_box`],
+    queryKey: [`${tourPreference}_bounding_box`],
     queryFn: async () => {
       return fetchBoundingBox(tourPreference);
     },


### PR DESCRIPTION
- when choosing a new tour, the correct bounding box will always be displayed
- when changing your preferred tour multiple times, it will no longer throw an error